### PR TITLE
Enable CI for PRs from forked repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: SonarCloud
+name: CI Setup
 on:
   push:
     branches:
@@ -6,8 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  sonarcloud:
-    name: SonarCloud
+  citest:
+    name: CI Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,11 +18,23 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install tox and any other packages
-        run: pip install tox
+        run: pip install "tox < 4" #tox has breaking changes in major version 4
       - name: Run tox
         run: make unittests
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Save PR number to file
+        run: echo ${{ github.event.number }} > PR_NUMBER.txt
+      - name: Archive PR number
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_NUMBER
+          path: PR_NUMBER.txt
+      - name: Save coverage report
+        run: |
+          report_root="/home/runner/work/prometheus-juju-exporter/prometheus-juju-exporter/tests/unit/report/"
+          cp ${report_root}/coverage.xml cov.xml
+          
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: ./cov.xml

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,109 @@
+name: SonarCloud
+on:
+  workflow_run:
+    workflows: [CI Setup]
+    types: [completed]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Echo event info
+        run: cat $GITHUB_EVENT_PATH
+      - name: Download PR number artifact
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: CI Setup
+          run_id: ${{ github.event.workflow_run.id }}
+          name: PR_NUMBER
+      - name: Read PR_NUMBER.txt
+        if: github.event.workflow_run.event == 'pull_request'
+        id: pr_number
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./PR_NUMBER.txt
+      - name: Request GitHub API for PR data
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: octokit/request-action@v2.x
+        id: get_pr_data
+        with:
+          route: GET /repos/{full_name}/pulls/{number}
+          number: ${{ steps.pr_number.outputs.content }}
+          full_name: ${{ github.event.repository.full_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Initialized repository
+        uses: actions/checkout@v3
+        with:
+            repository: ${{ github.event.workflow_run.head_repository.full_name }}
+            ref: ${{ github.event.workflow_run.head_branch }}
+            fetch-depth: 0
+      - name: Checkout base branch
+        if: github.event.workflow_run.event == 'pull_request'
+        run: |
+            git remote add upstream ${{ github.event.repository.clone_url }}
+            git fetch upstream
+            git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+            git checkout ${{ github.event.workflow_run.head_branch }}
+            git clean -ffdx && git reset --hard HEAD
+      
+      - name: Download coverage report
+        uses: actions/github-script@v5
+        with:
+            script: |
+              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+              });
+              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+                return artifact.name == "coverage-report"
+              })[0];
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+              let fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
+              
+      - name: Unzip code coverage
+        run: unzip artifact.zip
+        
+      - name: Fix code coverage paths
+        working-directory: .
+        run: |
+            mkdir tests/unit/report
+            cp cov.xml tests/unit/report/coverage.xml
+
+      - name: SonarCloud Scan on PR
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: '.'
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}
+            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
+            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+            -Dproject.settings=sonar-project.properties
+
+      - name: SonarCloud Scan on push
+        if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == ${{ github.event.workflow_run.head_repository.full_name }}
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: '.'
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
+            -Dproject.settings=sonar-project.properties


### PR DESCRIPTION
This PR updates the CI to address empty credential issue when opening PRs from an forked repo ([example](https://github.com/canonical/prometheus-juju-exporter/actions/runs/3639569364/jobs/6143120444)).

Github Action has [`workflow_run`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) feature that runs a workflow "based on execution or completion of another workflow". Because the second workflow is triggered within the upstream repo, It is able to access secrets/tokens. In this case, CI tests is the first workflow. Upon its successful completion, SonarCloud workflow gets triggered and starts the execution.

One thing to note is that, because SonarCloud workflow is not initiated by a PR, it doesn't have the correct code coverage for scanning and analyzing. To workaround this issue, PR number and coverage report need to be recorded by the first workflow (CI Setup) and passed to the second ([reference](https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/32)).