### PR TITLE
Bump snap grade to stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   Collects juju machine status metrics periodically.
   Provides a prometheus exporter interface exposing the collected metrics.
 
-grade: devel
+grade: stable
 confinement: strict
 
 apps:


### PR DESCRIPTION
Update `grade` of the snap so we can release it to `stable` channel.