### PR TITLE
Split "collect" and "export" functionalities into separate subcommands.

### DIFF
--- a/prometheus_juju_exporter/cli.py
+++ b/prometheus_juju_exporter/cli.py
@@ -34,11 +34,9 @@ def collect(pretty: bool = False) -> None:
     collector = Collector()
     indent = 2 if pretty else None
 
-    loop = asyncio.get_event_loop()
-    task = asyncio.ensure_future(collector.get_stats())
-    loop.run_until_complete(asyncio.wait([task]))
+    result = asyncio.run(collector.get_stats())
 
-    print(json.dumps(task.result(), indent=indent))
+    print(json.dumps(result, indent=indent))
 
 
 def export() -> None:

--- a/prometheus_juju_exporter/config.py
+++ b/prometheus_juju_exporter/config.py
@@ -51,7 +51,7 @@ class Config:
 
         try:
             self.config.get(template)
-            self.logger.info("Configuration parsed successfully")
+            self.logger.debug("Configuration parsed successfully")
         except (
             KeyError,
             confuse.ConfigTypeError,

--- a/prometheus_juju_exporter/exporter.py
+++ b/prometheus_juju_exporter/exporter.py
@@ -72,16 +72,14 @@ class ExporterDaemon:
         while run_collector:
             try:
                 self.logger.info("Collecting gauges...")
-                raw_data = subprocess.check_output(
-                    collector_cmd, stderr=subprocess.STDOUT
-                )
+                raw_data = subprocess.check_output(collector_cmd)
                 data = json.loads(raw_data)
                 self.update_registry(data)
                 self.logger.info("Gauges collected and ready for exporting.")
                 sleep(self.config["exporter"]["collect_interval"].get(int) * 60)
             except Exception as exc:
                 err = (
-                    exc.output
+                    exc.output + exc.stderr
                     if isinstance(exc, subprocess.CalledProcessError)
                     else str(exc)
                 )


### PR DESCRIPTION
This is a workaround for a memory leak that occurred when the long running process (exporter) was using libjuju directly. Things that have been changed:

* CLI was split into two (mandatory) sub-commands `export` and `collect`
* `prometheus-juju-exporter collect` gathers the data from controller and prints the output to STDOUT as a json
* `prometheus-juju-exporter export` runs the Prometheus exporter and periodically executes `prometheus-juju-exporter collect` as a subprocess to get updated data

With this structure, libjuju objects are created only in the short-lived process `prometheus-juju-exporter collect` and therfore can't cause memory leak in the long living process `prometheus-juju-exporter export`

Note: This is just a working version to get some feedback. Unit tests were not adjusted yet.

TODO before potential merge:
* Update UTs
* Update and test snap version
* Update charm that uses this exporter