### PR TITLE
Disconnect each model to prevent memory leak.

### DIFF
--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -91,6 +91,7 @@ class Collector:
         """
         model = await self.controller.get_model(uuid)
         status = await model.get_status()
+        await model.disconnect()
 
         return status["machines"]
 


### PR DESCRIPTION
If models are not disconnected, libjuju keeps alive websocket connections to them. This, over time, massively increases memory usage as the connections are never terminated.

This is a lightweight alternative solution to #13 . I'm currently running long tests to be completely sure that memory usage is fixed but so far it looks promissing.