### PR TITLE
Handles keyinterrupt and add func tests to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   citest:
-    name: CI Test
+    name: Lint and Unittests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/functest.yaml
+++ b/.github/workflows/functest.yaml
@@ -1,0 +1,33 @@
+name: Functional tests
+on:
+  pull_request_review:
+    types: [ submitted ]
+jobs:
+  functest:
+    name: Functional tests
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.review.state == 'approved'
+      || github.event.review.body == 'recheck'
+      || github.event.review.body == 'recheck-full'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install tox
+        run: pip install "tox < 4" #tox has breaking changes in major version 4
+      - name: Set up LXD
+        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+      - name: Install and bootstrap juju
+        run: |
+          sudo snap install juju --classic --channel=2.9/stable
+          juju bootstrap lxd localcloud
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+      - name: Run functional tests
+        run: make functional

--- a/prometheus_juju_exporter/exporter.py
+++ b/prometheus_juju_exporter/exporter.py
@@ -61,9 +61,7 @@ class ExporterDaemon:
                 )
                 self.metrics[gauge_name].remove(*labels)
 
-    async def trigger(
-        self,
-    ) -> None:
+    async def trigger(self) -> None:
         """Call Collector and configure prometheus_client gauges from generated stats."""
         while True:
             try:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -5,7 +5,7 @@ from subprocess import check_call, check_output
 import pytest
 import yaml
 
-JUJU_CRED_DIR = "/home/ubuntu/.local/share/juju/"
+JUJU_CRED_DIR = ".local/share/juju/"
 SNAP_CONFIG_DIR = "/var/snap/prometheus-juju-exporter/"
 TMP_DIR = "/tmp"
 SNAP_NAME = "prometheus-juju-exporter"
@@ -13,8 +13,8 @@ SNAP_NAME = "prometheus-juju-exporter"
 
 def get_juju_data():
     """Get juju account data and credentials."""
-    juju_controller_file = os.path.join(JUJU_CRED_DIR, "controllers.yaml")
-    juju_account_file = os.path.join(JUJU_CRED_DIR, "accounts.yaml")
+    juju_controller_file = os.path.join(os.path.expanduser("~"), JUJU_CRED_DIR, "controllers.yaml")
+    juju_account_file = os.path.join(os.path.expanduser("~"), JUJU_CRED_DIR, "accounts.yaml")
     assert os.path.isfile(juju_controller_file)
     assert os.path.isfile(juju_account_file)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,8 +13,12 @@ SNAP_NAME = "prometheus-juju-exporter"
 
 def get_juju_data():
     """Get juju account data and credentials."""
-    juju_controller_file = os.path.join(os.path.expanduser("~"), JUJU_CRED_DIR, "controllers.yaml")
-    juju_account_file = os.path.join(os.path.expanduser("~"), JUJU_CRED_DIR, "accounts.yaml")
+    juju_controller_file = os.path.join(
+        os.path.expanduser("~"), JUJU_CRED_DIR, "controllers.yaml"
+    )
+    juju_account_file = os.path.join(
+        os.path.expanduser("~"), JUJU_CRED_DIR, "accounts.yaml"
+    )
     assert os.path.isfile(juju_controller_file)
     assert os.path.isfile(juju_account_file)
 

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -31,9 +31,8 @@ class TestExporterDaemon:
         with mock.patch(
             "prometheus_juju_exporter.exporter.asyncio.sleep",
             side_effect=Exception,
-        ):
-            with pytest.raises(SystemExit) as exit_call:
-                await statsd.trigger()
+        ), pytest.raises(SystemExit) as exit_call:
+            await statsd.trigger()
 
         statsd.collector.get_stats.assert_called_once()
         assert "example_gauge" in statsd.metrics.keys()
@@ -48,9 +47,8 @@ class TestExporterDaemon:
         with mock.patch(
             "prometheus_juju_exporter.exporter.ExporterDaemon.trigger",
             side_effect=KeyboardInterrupt,
-        ):
-            with pytest.raises(SystemExit) as exit_call:
-                statsd.run()
+        ), pytest.raises(SystemExit) as exit_call:
+            statsd.run()
 
         assert exit_call.type == SystemExit
         assert exit_call.value.code == 0

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -27,26 +27,30 @@ class TestExporterDaemon:
     async def test_trigger(self, exporter_daemon):
         """Test trigger function."""
         statsd = exporter_daemon()
-        await statsd.trigger(once=True)
+
+        with mock.patch(
+            "prometheus_juju_exporter.exporter.asyncio.sleep",
+            side_effect=Exception,
+        ):
+            with pytest.raises(SystemExit) as exit_call:
+                await statsd.trigger()
 
         statsd.collector.get_stats.assert_called_once()
         assert "example_gauge" in statsd.metrics.keys()
 
-    @pytest.mark.asyncio
-    async def test_trigger_exception(self, exporter_daemon):
-        """Test exception handling of trigger function."""
-        statsd = exporter_daemon()
-
-        with mock.patch(
-            "prometheus_juju_exporter.collector.Collector.get_stats",
-            side_effect=Exception("mocked error"),
-        ):
-            with mock.patch("prometheus_juju_exporter.exporter.sys.exit") as exit_call:
-                await statsd.trigger(once=True)
-                exit_call.assert_called_once()
+        assert exit_call.type == SystemExit
+        assert exit_call.value.code == 1
 
     def test_run(self, exporter_daemon):
         """Test run function."""
         statsd = exporter_daemon()
-        statsd.run(once=True)
-        statsd.collector.get_stats.assert_called_once()
+
+        with mock.patch(
+            "prometheus_juju_exporter.exporter.ExporterDaemon.trigger",
+            side_effect=KeyboardInterrupt,
+        ):
+            with pytest.raises(SystemExit) as exit_call:
+                statsd.run()
+
+        assert exit_call.type == SystemExit
+        assert exit_call.value.code == 0


### PR DESCRIPTION
This PR removes the `**kwargs` in `Exporter.trigger()` and `Exporter.run()` function because it only serves testing purposes. Instead, gracefully shutdown with key interrupt is implemented.

This PR also adds functional tests to the CI workflow for a more complete validation. 

Fixes: #8 