### PR TITLE
Update README to include snap configuration requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ To get the latest development version of the snap, build from the source code an
 make build
 sudo snap install --dangerous prometheus-juju-exporter.snap
 ```
+
+## Configuration
+By default, prometheus-juju-exporter uses the configuration specified in [config_default.yaml](prometheus-juju-exporter/config_default.yaml). It's likely not fitting your need because the values provided are generic and for demonstration purposes only. To configure the snap for your own environment, create a `config.yaml` file in `$SNAP_DATA` (see [Snap Environment Variables](https://snapcraft.io/docs/environment-variables)) directory with the desired entries.
+
+The snap requires juju user's credentials to connect to a controller and all of its models. The credentials are set as `juju.username` and `juju.password` config values. Normally, **`superuser`** privilege is expected for such a user for full access to the controller. However, in case it is not possible, the minimum privilege requirements are:
+1. `login` access to controller, and
+2. `admin` access to all *active* models (including the `controller` model)

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ sudo snap install --dangerous prometheus-juju-exporter.snap
 By default, prometheus-juju-exporter uses the configuration specified in [config_default.yaml](prometheus-juju-exporter/config_default.yaml). It's likely not fitting your need because the values provided are generic and for demonstration purposes only. To configure the snap for your own environment, create a `config.yaml` file in `$SNAP_DATA` (see [Snap Environment Variables](https://snapcraft.io/docs/environment-variables)) directory with the desired entries.
 
 The snap requires juju user's credentials to connect to a controller and all of its models. The credentials are set as `juju.username` and `juju.password` config values. Normally, **`superuser`** privilege is expected for such a user for full access to the controller. However, in case it is not possible, the minimum privilege requirements are:
-1. `login` access to controller, and
-2. `admin` access to all *active* models (including the `controller` model)
+1. `login` access to the controller instance and `admin` access to the model hosting the controller
+2. `admin` access to any model that's expected to be monitored by this exporter


### PR DESCRIPTION
The snap requires specific user privileges to interact with juju controller and scan through its models. This PR updates README to include such information.