### PR TITLE
Allow virtual MAC address detection overrides

### DIFF
--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -138,7 +138,10 @@ class Collector:
 
             for i in interfaces:
                 mac_addresses = i["mac-address"]
-                if mac_addresses.startswith(tuple(virt_mac_prefixes)):
+                if (
+                    mac_addresses.startswith(tuple(virt_mac_prefixes))
+                    and virt_mac_prefixes[0] != ""
+                ):
                     machine_type = MachineType.KVM
                     break
 

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -27,6 +27,7 @@ class Collector:
         self.data: Dict[str, Any] = {}
         self.currently_cached_labels: Dict[str, Any] = {}
         self.previously_cached_labels: Dict[str, Any] = {}
+        self.virt_mac_prefixes = self.config["detection"]["virt_macs"].as_str_seq()
         self.logger.debug("Collector initialized")
 
     def refresh_cache(
@@ -120,6 +121,21 @@ class Collector:
         for label in stale_labels.values():
             self.data[gauge_name]["labelvalues_remove"].append(list(label[0].values()))
 
+    def _get_machine_type(self, machine: Dict) -> MachineType:
+        """Detect machine type based on its MAC address.
+
+        :param dict machine: status information for a machine
+        :return MachineType: MachineType class object indicating the machine type
+        """
+        interfaces = machine["network-interfaces"].values()
+
+        for i in interfaces:
+            mac_address = i["mac-address"]
+            if mac_address.startswith(tuple(self.virt_mac_prefixes)):
+                return MachineType.KVM
+
+        return MachineType.METAL
+
     async def _get_machine_stats(
         self, machines: Dict, model_name: str, gauge_name: str
     ) -> None:
@@ -129,19 +145,8 @@ class Collector:
         :param str model_name: the name of the model the machines are in
         :param str gauge_name: the name of the gauge
         """
-        virt_mac_prefixes = self.config["detection"]["virt_macs"].as_str_seq()
-
         for machine in machines.values():
-            # check machine type with the prefix of its mac address
-            interfaces = machine["network-interfaces"].values()
-            machine_type = MachineType.METAL
-
-            for i in interfaces:
-                mac_address = i["mac-address"]
-                if mac_address.startswith(tuple(virt_mac_prefixes)):
-                    machine_type = MachineType.KVM
-                    break
-
+            machine_type = self._get_machine_type(machine)
             value = self._get_gauge_value(status=machine["agent-status"]["status"])
 
             labels = self._create_gauge_label(

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -129,7 +129,7 @@ class Collector:
         :param str model_name: the name of the model the machines are in
         :param str gauge_name: the name of the gauge
         """
-        virt_mac_prefixes = self.config["machine"]["virt_macs"].get(str).split(",")
+        virt_mac_prefixes = self.config["detection"]["virt_macs"].as_str_seq()
 
         for machine in machines.values():
             # check machine type with the prefix of its mac address
@@ -137,11 +137,8 @@ class Collector:
             machine_type = MachineType.METAL
 
             for i in interfaces:
-                mac_addresses = i["mac-address"]
-                if (
-                    mac_addresses.startswith(tuple(virt_mac_prefixes))
-                    and virt_mac_prefixes[0] != ""
-                ):
+                mac_address = i["mac-address"]
+                if mac_address.startswith(tuple(virt_mac_prefixes)):
                     machine_type = MachineType.KVM
                     break
 

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -28,14 +28,6 @@ class Collector:
         self.currently_cached_labels: Dict[str, Any] = {}
         self.previously_cached_labels: Dict[str, Any] = {}
         self.logger.debug("Collector initialized")
-        self.prefixes = [
-            "52:54:00",
-            "fa:16:3e",
-            "06:f1:3a",
-            "00:0d:3a",
-            "00:50:56",
-            "fa:16:3e",
-        ]
 
     def refresh_cache(
         self, gauge_name: str, gauge_desc: str, labels: List[str]
@@ -137,6 +129,8 @@ class Collector:
         :param str model_name: the name of the model the machines are in
         :param str gauge_name: the name of the gauge
         """
+        virt_mac_prefixes = self.config["machine"]["virt_macs"].get(str).split(",")
+
         for machine in machines.values():
             # check machine type with the prefix of its mac address
             interfaces = machine["network-interfaces"].values()
@@ -144,7 +138,7 @@ class Collector:
 
             for i in interfaces:
                 mac_addresses = i["mac-address"]
-                if mac_addresses.startswith(tuple(self.prefixes)):
+                if mac_addresses.startswith(tuple(virt_mac_prefixes)):
                     machine_type = MachineType.KVM
                     break
 

--- a/prometheus_juju_exporter/config.py
+++ b/prometheus_juju_exporter/config.py
@@ -56,6 +56,7 @@ class Config(metaclass=ConfigMeta):
                 ]
             ),
             "customer": OrderedDict([("name", str), ("cloud_name", str)]),
+            "machine": OrderedDict([("virt_macs", str)]),
         }
 
         try:

--- a/prometheus_juju_exporter/config.py
+++ b/prometheus_juju_exporter/config.py
@@ -56,7 +56,7 @@ class Config(metaclass=ConfigMeta):
                 ]
             ),
             "customer": OrderedDict([("name", str), ("cloud_name", str)]),
-            "machine": OrderedDict([("virt_macs", str)]),
+            "detection": OrderedDict([("virt_macs", confuse.StrSeq())]),
         }
 
         try:

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -12,5 +12,10 @@ exporter:
   port: 9748
   collect_interval: 15
 
-machine:
-  virt_macs: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"
+detection: # parameters affecting the detection algorithm
+  virt_macs: 
+    - "52:54:00"
+    - "fa:16:3e"
+    - "06:f1:3a"
+    - "00:0d:3a" # Microsoft
+    - "00:50:56" # VMware

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -11,3 +11,6 @@ juju:
 exporter:
   port: 9748
   collect_interval: 15
+
+machine:
+  virt_macs: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"

--- a/tests/unit/config.yaml
+++ b/tests/unit/config.yaml
@@ -12,5 +12,10 @@ exporter:
   port: 9748
   collect_interval: 15
 
-machine:
-  virt_macs: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"
+detection:
+  virt_macs:
+    - "52:54:00"
+    - "fa:16:3e"
+    - "06:f1:3a"
+    - "00:0d:3a"
+    - "00:50:56"

--- a/tests/unit/config.yaml
+++ b/tests/unit/config.yaml
@@ -11,3 +11,6 @@ juju:
 exporter:
   port: 9748
   collect_interval: 15
+
+machine:
+  virt_macs: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -25,10 +25,13 @@ class TestCollectorDaemon:
         assert statsd.config["juju"]["password"].get() == "example_password"
         assert statsd.config["customer"]["name"].get() == "example_customer"
         assert statsd.config["customer"]["cloud_name"].get() == "example_cloud"
-        assert (
-            statsd.config["machine"]["virt_macs"].get()
-            == "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"
-        )
+        assert statsd.config["detection"]["virt_macs"].get() == [
+            "52:54:00",
+            "fa:16:3e",
+            "06:f1:3a",
+            "00:0d:3a",
+            "00:50:56",
+        ]
 
     @pytest.mark.asyncio
     async def test_get_stats(self, collector_daemon):

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -25,6 +25,10 @@ class TestCollectorDaemon:
         assert statsd.config["juju"]["password"].get() == "example_password"
         assert statsd.config["customer"]["name"].get() == "example_customer"
         assert statsd.config["customer"]["cloud_name"].get() == "example_cloud"
+        assert (
+            statsd.config["machine"]["virt_macs"].get()
+            == "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"
+        )
 
     @pytest.mark.asyncio
     async def test_get_stats(self, collector_daemon):

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -133,3 +133,21 @@ class TestCollectorDaemon:
                 ],
             },
         }
+
+    @pytest.mark.parametrize(
+        "mac_address,expect_machine_type",
+        [("fa:16:3e:d4:00:00", "kvm"), ("00:00:00:00:00:00", "metal")],
+    )
+    def test_get_machine_type(self, collector_daemon, mac_address, expect_machine_type):
+        """Test get_stats function and the execution of the collector."""
+        statsd = collector_daemon()
+        machine = {
+            "network-interfaces": {
+                "ens3": {
+                    "mac-address": mac_address,
+                }
+            }
+        }
+        machine_type = statsd._get_machine_type(machine)
+
+        assert machine_type.value == expect_machine_type


### PR DESCRIPTION
This PR moves the default collection of virtual MAC prefixes to the config option, which enables overriding in non-standard virtual environment.