### PR TITLE
Handle "broken" model

### DIFF
--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -1,7 +1,7 @@
 """Collector module."""
 from enum import Enum
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from juju.controller import Controller
 
@@ -77,7 +77,7 @@ class Collector:
                 endpoint=endpoint, username=username, password=password, cacert=cacert
             )
 
-    async def _get_machines_in_model(self, uuid: str) -> Optional[Dict[Any, Any]]:
+    async def _get_machines_in_model(self, uuid: str) -> Dict[Any, Any]:
         """Get a list of all machines in the model with their stats.
 
         :return: status information for all machines in the model
@@ -88,7 +88,7 @@ class Collector:
             await model.disconnect()
         except Exception as err:  # pylint: disable=W0703
             self.logger.error("Failed connecting to model '%s': %s ", uuid, err)
-            return None
+            return {}
 
         return status["machines"]
 
@@ -229,10 +229,9 @@ class Collector:
                 self.logger.debug("Checking model '%s'...", name)
                 machines = await self._get_machines_in_model(uuid=uuid_)
 
-                if machines:
-                    await self._get_machine_stats(
-                        machines=machines, model_name=name, gauge_name=gauge_name
-                    )
+                await self._get_machine_stats(
+                    machines=machines, model_name=name, gauge_name=gauge_name
+                )
 
             self._get_labels_to_remove(gauge_name=gauge_name)
         finally:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -288,7 +288,7 @@ def exporter_daemon(monkeypatch, stats_gauge):
 
 
 @pytest.fixture
-def collector_daemon(monkeypatch, mock_model_connection, mock_controller_connection):
+def collector_daemon(monkeypatch, mock_controller_connection):
     """Mock collector."""
     from prometheus_juju_exporter.collector import Collector
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -179,4 +179,3 @@ class TestCollectorDaemon:
         machine_type = statsd._get_machine_type(machine)
 
         assert machine_type.value == expect_machine_type
-

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 """Test collctor."""
+from unittest import mock
+
 import pytest
 
 
@@ -125,4 +127,30 @@ class TestCollectorDaemon:
                     ),
                 ],
             },
+        }
+
+    @pytest.mark.asyncio
+    async def test_skip_inaccessible_models(self, collector_daemon):
+        """Test exception handling in case a model is inaccessible."""
+        statsd = collector_daemon()
+        with mock.patch(
+            "prometheus_juju_exporter.collector.Controller.get_model",
+            side_effect=Exception,
+        ):
+            await statsd.get_stats()
+
+        assert statsd.data == {
+            "juju_machine_state": {
+                "gauge_desc": "Running status of juju machines",
+                "labels": [
+                    "job",
+                    "hostname",
+                    "customer",
+                    "cloud_name",
+                    "juju_model",
+                    "type",
+                ],
+                "labelvalues_remove": [],
+                "labelvalues_update": [],
+            }
         }


### PR DESCRIPTION
This PR modified model connection method to skip inaccessible models and continue.

Fixes: #17 