### PR TITLE
Enable exporter service on install

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,6 @@ confinement: strict
 apps:
   prometheus-juju-exporter:
     daemon: simple
-    install-mode: disable
     restart-condition: on-abnormal
     command: bin/prometheus-juju-exporter
     plugs: [network, network-bind]


### PR DESCRIPTION
Setting snap as "disabled" on install was originally my idea, but it has no added value currently. Service is unable to run without correct config anyway and it only adds responsibility of enabling the service to charm.