### PR TITLE
collector: get sensible machine hostname

### DIFF
--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -153,18 +153,25 @@ class Collector:
         :return str: a valid identifier string for the machine if
             applicable, else the string literal "None".
         """
+        self.logger.debug("Trying to find an identifier for machine: %s", str(machine))
         machine_id = "None"
         for field in ["hostname", "instance-id"]:
             candidate = machine.get(field, None)
-            self.logger.debug("Candidate hostname:[%s] in field:[%s]", candidate, field)
+            self.logger.debug(
+                "Candidate machine id:[%s] in field:[%s]", candidate, field
+            )
             if candidate not in [None, "None"]:
                 machine_id = candidate
                 self.logger.debug(
-                    "Selecting sensible hostname:[%s] in field:[%s]",
+                    "Selecting machine id:[%s] in field:[%s]",
                     machine_id,
                     field,
                 )
                 break
+        if machine_id == "None":
+            self.logger.error(
+                "Failed to find a machine identifier for machine: %s", str(machine)
+            )
         return machine_id
 
     async def _get_machine_stats(

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -1,7 +1,7 @@
 """Collector module."""
 from enum import Enum
 from logging import getLogger
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from juju.controller import Controller
 
@@ -97,7 +97,7 @@ class Collector:
         """
         return {
             "job": "prometheus-juju-exporter",
-            "hostname": str(hostname),
+            "hostname": hostname,
             "customer": self.config["customer"]["name"].get(str),
             "cloud_name": self.config["customer"]["cloud_name"].get(str),
             "juju_model": model_name,
@@ -140,7 +140,7 @@ class Collector:
 
         return MachineType.METAL
 
-    def _get_machine_sensible_hostname(self, machine: Dict) -> Union[str, None]:
+    def _get_machine_sensible_hostname(self, machine: Dict) -> str:
         """Try to find a sensible hostname for the machine.
 
         The hostname field is only supported for juju controller versions
@@ -150,23 +150,19 @@ class Collector:
         field, which seems to exist almost always.
 
         :param dict machine: status information for a machine
-        :return Union[str, None]: a sensible hostname string for the machine if
-            applicable, else None.
+        :return str: a sensible hostname string for the machine if
+            applicable, else the string literal "None".
         """
-        sensible_hostname = None
+        sensible_hostname = "None"
         for field in ["hostname", "instance-id"]:
             candidate = machine.get(field, None)
-            self.logger.debug(
-                "Candidate hostname:[%s] in field:[%s]",
-                candidate,
-                field
-            )
+            self.logger.debug("Candidate hostname:[%s] in field:[%s]", candidate, field)
             if candidate not in [None, "None"]:
                 sensible_hostname = candidate
                 self.logger.debug(
                     "Selecting sensible hostname:[%s] in field:[%s]",
                     sensible_hostname,
-                    field
+                    field,
                 )
                 break
         return sensible_hostname

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -160,7 +160,7 @@ class Collector:
             self.logger.debug(
                 "Candidate machine id:[%s] in field:[%s]", candidate, field
             )
-            if candidate not in [None, "None"]:
+            if candidate not in [None, "None", "pending"]:
                 machine_id = candidate
                 self.logger.debug(
                     "Selecting machine id:[%s] in field:[%s]",

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -140,8 +140,8 @@ class Collector:
 
         return MachineType.METAL
 
-    def _get_machine_identifier(self, machine: Dict) -> str:
-        """Try to find a valid identifier for the machine.
+    def _get_host_identifier(self, host: Dict) -> str:
+        """Try to find a valid identifier for the host.
 
         The hostname field is only supported for juju controller versions
         2.8.10 and upwards. For the remaining lower versions, this field
@@ -149,30 +149,38 @@ class Collector:
         hostname if it can, else it will try to get it from the "instance-id"
         field, which seems to exist almost always.
 
-        :param dict machine: status information for a machine
-        :return str: a valid identifier string for the machine if
+        The instance-id with the value "pending" is also treated specially.
+        This value is observed when model status data was gathered
+        during machine/container creation phase. In this case, an info is
+        issued for the operator and this host will be treated as there is no
+        valid identifier.
+
+        :param dict machine: status dictionary for a machine or container
+        :return str: a valid identifier string for the host if
             applicable, else the string literal "None".
         """
-        self.logger.debug("Trying to find an identifier for machine: %s", str(machine))
-        machine_id = "None"
+        self.logger.debug("Trying to find an identifier for host: %s", str(host))
+        host_id = "None"
         for field in ["hostname", "instance-id"]:
-            candidate = machine.get(field, None)
-            self.logger.debug(
-                "Candidate machine id:[%s] in field:[%s]", candidate, field
-            )
-            if candidate not in [None, "None", "pending"]:
-                machine_id = candidate
+            candidate = host.get(field, None)
+            if candidate not in [None, "None"]:
+                host_id = candidate
                 self.logger.debug(
-                    "Selecting machine id:[%s] in field:[%s]",
-                    machine_id,
+                    "Candidate host id:[%s] in field:[%s]",
+                    host_id,
                     field,
                 )
                 break
-        if machine_id == "None":
-            self.logger.error(
-                "Failed to find a machine identifier for machine: %s", str(machine)
-            )
-        return machine_id
+
+        if host_id == "pending":
+            self.logger.info("Found host with pending identifier. Skipping.")
+            return "None"
+
+        if host_id == "None":
+            self.logger.error("Failed to find identifier for host: %s", str(host))
+        else:
+            self.logger.debug("Found identifier for host: %s", host_id)
+        return host_id
 
     async def _get_machine_stats(
         self, machines: Dict, model_name: str, gauge_name: str
@@ -186,7 +194,7 @@ class Collector:
         for machine in machines.values():
             machine_type = self._get_machine_type(machine)
             value = self._get_gauge_value(status=machine["agent-status"]["status"])
-            machine_id = self._get_machine_identifier(machine)
+            machine_id = self._get_host_identifier(machine)
 
             if machine_id != "None":
                 labels = self._create_gauge_label(
@@ -200,13 +208,13 @@ class Collector:
                 )
                 self.data[gauge_name]["labelvalues_update"].append((labels, value))
 
-            self._get_container_status(
+            self._get_container_stats(
                 containers=machine["containers"],
                 model_name=model_name,
                 gauge_name=gauge_name,
             )
 
-    def _get_container_status(
+    def _get_container_stats(
         self, containers: Dict, model_name: str, gauge_name: str
     ) -> None:
         """Get lxd containers stats.
@@ -217,15 +225,15 @@ class Collector:
         """
         for container in containers.values():
             value = self._get_gauge_value(container["agent-status"]["status"])
-            machine_id = self._get_machine_identifier(container)
+            container_id = self._get_host_identifier(container)
 
-            if machine_id != "None":
+            if container_id != "None":
                 labels = self._create_gauge_label(
-                    hostname=machine_id,
+                    hostname=container_id,
                     model_name=model_name,
                     machine_type=MachineType.LXD.value,
                 )
-                self.currently_cached_labels[machine_id] = (
+                self.currently_cached_labels[container_id] = (
                     labels.copy(),
                     value,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ skip_glob = '''
 [tool.pylint]
 max-line-length = 120
 ignore = ['.eggs', '.git', '.tox', '.venv', '.build', 'report', 'tests']
+disable = ['C0204']
 
 [tool.mypy]
 warn_unused_ignores = true

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -36,7 +36,20 @@ class TestCollectorDaemon:
         ]
 
     @pytest.mark.asyncio
-    async def test_get_stats(self, collector_daemon):
+    @pytest.mark.parametrize(
+        # fmt: off
+        "update_model_status",
+        [
+            {},
+            {"machines": {"0": {"hostname": "None", "instance-id": "juju-000ddd-test-0"}}},
+            {"machines": {"0": {"hostname": None, "instance-id": "juju-000ddd-test-0"}}},
+            {"machines": {"0": {"containers": {"0/lxd/0": {"hostname": "None"}}}}},
+            {"machines": {"0": {"containers": {"0/lxd/0": {"hostname": None}}}}},
+        ],
+        indirect=True,
+        # fmt: on
+    )
+    async def test_get_stats(self, collector_daemon, update_model_status):
         """Test get_stats function and the execution of the collector."""
         statsd = collector_daemon()
         statsd.currently_cached_labels = {

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -179,3 +179,26 @@ class TestCollectorDaemon:
         machine_type = statsd._get_machine_type(machine)
 
         assert machine_type.value == expect_machine_type
+
+    @pytest.mark.parametrize(
+        "machine, hostname",
+        [
+            ({"hostname": None, "instance-id": "testid"}, "testid"),
+            ({"hostname": "None", "instance-id": "testid"}, "testid"),
+            ({"hostname": "testhost", "instance-id": "testid"}, "testhost"),
+            ({"hostname": None, "instance-id": None}, None),
+            ({"hostname": None, "instance-id": "None"}, None),
+            ({"hostname": "None", "instance-id": None}, None),
+            ({"hostname": "None", "instance-id": "None"}, None),
+            ({"hostname": "testhost"}, "testhost"),
+            ({"hostname": None}, None),
+            ({"hostname": "None"}, None),
+            ({"instance-id": "testid"}, "testid"),
+            ({"instance-id": None}, None),
+            ({"instance-id": "None"}, None),
+            ({}, None)
+        ]
+    )
+    def test_get_machine_sensible_hostname(self, collector_daemon, machine, hostname):
+        """Test getting a sensible hostname from machine data."""
+        assert collector_daemon()._get_machine_sensible_hostname(machine) == hostname

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -186,18 +186,18 @@ class TestCollectorDaemon:
             ({"hostname": None, "instance-id": "testid"}, "testid"),
             ({"hostname": "None", "instance-id": "testid"}, "testid"),
             ({"hostname": "testhost", "instance-id": "testid"}, "testhost"),
-            ({"hostname": None, "instance-id": None}, None),
-            ({"hostname": None, "instance-id": "None"}, None),
-            ({"hostname": "None", "instance-id": None}, None),
-            ({"hostname": "None", "instance-id": "None"}, None),
+            ({"hostname": None, "instance-id": None}, "None"),
+            ({"hostname": None, "instance-id": "None"}, "None"),
+            ({"hostname": "None", "instance-id": None}, "None"),
+            ({"hostname": "None", "instance-id": "None"}, "None"),
             ({"hostname": "testhost"}, "testhost"),
-            ({"hostname": None}, None),
-            ({"hostname": "None"}, None),
+            ({"hostname": None}, "None"),
+            ({"hostname": "None"}, "None"),
             ({"instance-id": "testid"}, "testid"),
-            ({"instance-id": None}, None),
-            ({"instance-id": "None"}, None),
-            ({}, None)
-        ]
+            ({"instance-id": None}, "None"),
+            ({"instance-id": "None"}, "None"),
+            ({}, "None"),
+        ],
     )
     def test_get_machine_sensible_hostname(self, collector_daemon, machine, hostname):
         """Test getting a sensible hostname from machine data."""

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -194,7 +194,7 @@ class TestCollectorDaemon:
         assert machine_type.value == expect_machine_type
 
     @pytest.mark.parametrize(
-        "machine, machine_id",
+        "host, host_id",
         [
             ({"hostname": None, "instance-id": "testid"}, "testid"),
             ({"hostname": "None", "instance-id": "testid"}, "testid"),
@@ -203,15 +203,17 @@ class TestCollectorDaemon:
             ({"hostname": None, "instance-id": "None"}, "None"),
             ({"hostname": "None", "instance-id": None}, "None"),
             ({"hostname": "None", "instance-id": "None"}, "None"),
+            ({"hostname": None, "instance-id": "pending"}, "None"),
             ({"hostname": "testhost"}, "testhost"),
             ({"hostname": None}, "None"),
             ({"hostname": "None"}, "None"),
             ({"instance-id": "testid"}, "testid"),
             ({"instance-id": None}, "None"),
             ({"instance-id": "None"}, "None"),
+            ({"instance-id": "pending"}, "None"),
             ({}, "None"),
         ],
     )
-    def test_get_machine_identifier(self, collector_daemon, machine, machine_id):
-        """Test getting a valid machine id from machine data."""
-        assert collector_daemon()._get_machine_identifier(machine) == machine_id
+    def test_get_host_identifier(self, collector_daemon, host, host_id):
+        """Test getting a valid host id from host data."""
+        assert collector_daemon()._get_host_identifier(host) == host_id

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -181,7 +181,7 @@ class TestCollectorDaemon:
         assert machine_type.value == expect_machine_type
 
     @pytest.mark.parametrize(
-        "machine, hostname",
+        "machine, machine_id",
         [
             ({"hostname": None, "instance-id": "testid"}, "testid"),
             ({"hostname": "None", "instance-id": "testid"}, "testid"),
@@ -199,6 +199,6 @@ class TestCollectorDaemon:
             ({}, "None"),
         ],
     )
-    def test_get_machine_sensible_hostname(self, collector_daemon, machine, hostname):
-        """Test getting a sensible hostname from machine data."""
-        assert collector_daemon()._get_machine_sensible_hostname(machine) == hostname
+    def test_get_machine_identifier(self, collector_daemon, machine, machine_id):
+        """Test getting a valid machine id from machine data."""
+        assert collector_daemon()._get_machine_identifier(machine) == machine_id


### PR DESCRIPTION
The "hostname" field in the machine status information coming from libjuju is not very stable for controllers with older versions starting from 2.8.9. We are trying to fall back to using "instance-id" field in the case hostname is unavailable or none.

Works-on: #24, #25