### PR TITLE
Add feature to skip certain interfaces when detecting HW type

### DIFF
--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -135,7 +135,7 @@ class Collector:
         self.logger.debug("Determining type of machine: %s", machine_id)
         machine_type = MachineType.METAL
         skip_interfaces = self.config["detection"]["skip_interfaces"].as_str_seq()
-        interface_filter = re.compile(r"(?=(" + "|".join(skip_interfaces) + r"))")
+        interface_filter = re.compile(r"|".join(skip_interfaces))
 
         for interface, properties in machine["network-interfaces"].items():
             if skip_interfaces and interface_filter.search(interface) is not None:
@@ -147,9 +147,7 @@ class Collector:
                 continue
 
             mac_address = properties["mac-address"]
-            self.logger.debug(
-                "Considering interface %s with MAC: %s", interface, mac_address
-            )
+            self.logger.debug("Considering interface %s with MAC: %s", interface, mac_address)
             if mac_address.startswith(tuple(self.virt_mac_prefixes)):
                 machine_type = MachineType.KVM
                 break

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -1,4 +1,5 @@
 """Collector module."""
+import re
 from enum import Enum
 from logging import getLogger
 from typing import Any, Dict, List
@@ -125,20 +126,36 @@ class Collector:
         for label in stale_labels.values():
             self.data[gauge_name]["labelvalues_remove"].append(list(label[0].values()))
 
-    def _get_machine_type(self, machine: Dict) -> MachineType:
+    def _get_machine_type(self, machine: Dict, machine_id: str) -> MachineType:
         """Detect machine type based on its MAC address.
 
         :param dict machine: status information for a machine
         :return MachineType: MachineType class object indicating the machine type
         """
-        interfaces = machine["network-interfaces"].values()
+        self.logger.debug("Determining type of machine: %s", machine_id)
+        machine_type = MachineType.METAL
+        skip_interfaces = self.config["detection"]["skip_interfaces"].as_str_seq()
+        interface_filter = re.compile(r"(?=(" + "|".join(skip_interfaces) + r"))")
 
-        for i in interfaces:
-            mac_address = i["mac-address"]
+        for interface, properties in machine["network-interfaces"].items():
+            if skip_interfaces and interface_filter.search(interface) is not None:
+                self.logger.debug(
+                    "Disregarding interface %s. Matching filter: %s",
+                    interface,
+                    skip_interfaces,
+                )
+                continue
+
+            mac_address = properties["mac-address"]
+            self.logger.debug(
+                "Considering interface %s with MAC: %s", interface, mac_address
+            )
             if mac_address.startswith(tuple(self.virt_mac_prefixes)):
-                return MachineType.KVM
+                machine_type = MachineType.KVM
+                break
 
-        return MachineType.METAL
+        self.logger.debug("Machine %s is of type: %s", machine_id, machine_type)
+        return machine_type
 
     def _get_host_identifier(self, host: Dict) -> str:
         """Try to find a valid identifier for the host.
@@ -192,11 +209,11 @@ class Collector:
         :param str gauge_name: the name of the gauge
         """
         for machine in machines.values():
-            machine_type = self._get_machine_type(machine)
             value = self._get_gauge_value(status=machine["agent-status"]["status"])
             machine_id = self._get_host_identifier(machine)
 
             if machine_id != "None":
+                machine_type = self._get_machine_type(machine, machine_id)
                 labels = self._create_gauge_label(
                     hostname=machine_id,
                     model_name=model_name,

--- a/prometheus_juju_exporter/config.py
+++ b/prometheus_juju_exporter/config.py
@@ -56,7 +56,12 @@ class Config(metaclass=ConfigMeta):
                 ]
             ),
             "customer": OrderedDict([("name", str), ("cloud_name", str)]),
-            "detection": OrderedDict([("virt_macs", confuse.StrSeq())]),
+            "detection": OrderedDict(
+                [
+                    ("virt_macs", confuse.StrSeq()),
+                    ("skip_interfaces", confuse.StrSeq()),
+                ]
+            ),
         }
 
         try:

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -13,7 +13,8 @@ exporter:
   collect_interval: 15
 
 detection: # parameters affecting the detection algorithm
-  virt_macs: 
+  skip_interfaces: []  # regexp list of interfaces that should be skipped during hw typ detection
+  virt_macs:
     - "52:54:00"
     - "fa:16:3e"
     - "06:f1:3a"

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -13,7 +13,10 @@ exporter:
   collect_interval: 15
 
 detection: # parameters affecting the detection algorithm
-  skip_interfaces: []  # regexp list of interfaces that should be skipped during hw typ detection
+  skip_interfaces: [] 
+  # This option can be used to exclude interfaces that might confuse the detection algorithm.
+  # Takes a list of regexps as input. Any interface name matching any of the provided expressions will be skipped.
+  # For example: skip_interfaces: ["br.*", "tap-.*"] 
   virt_macs:
     - "52:54:00"
     - "fa:16:3e"

--- a/tests/unit/config.yaml
+++ b/tests/unit/config.yaml
@@ -13,6 +13,7 @@ exporter:
   collect_interval: 15
 
 detection:
+  skip_interfaces: []
   virt_macs:
     - "52:54:00"
     - "fa:16:3e"


### PR DESCRIPTION
Adds ability to specify to specify list of regular expressions. Interfaces whose names match any regexp in this list will not be considered when determining hardware type of the machine.

Closes #31 