### PR TITLE
Add ability to use only selected interfaces for machine type detection

### DIFF
--- a/prometheus_juju_exporter/config.py
+++ b/prometheus_juju_exporter/config.py
@@ -57,7 +57,7 @@ class Config(metaclass=ConfigMeta):
             "detection": OrderedDict(
                 [
                     ("virt_macs", confuse.StrSeq()),
-                    ("skip_interfaces", confuse.StrSeq()),
+                    ("match_interfaces", str),
                 ]
             ),
             "debug": bool,

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -17,7 +17,7 @@ detection: # parameters affecting the detection algorithm
   # Interface names that should be considered when detecting machine type.
   # Takes a single regexp string as input. Only interface names matching
   # the provided expression will be considered. The default value '' is
-  # empty value) tells the detection algorithm to look through all interfaces.
+  # equivalent to '.*' and tells the detection algorithm to look through all interfaces.
   # Example: match_interfaces: ^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+
   virt_macs: []
   # The list of MAC address prefixes to be considered as virtual machines.

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -13,15 +13,14 @@ exporter:
   collect_interval: 15
 
 detection: # parameters affecting the detection algorithm
-  skip_interfaces: [] 
-  # This option can be used to exclude interfaces that might confuse the detection algorithm.
-  # Takes a list of regexps as input. Any interface name matching any of the provided expressions will be skipped.
-  # For example: skip_interfaces: ["br.*", "tap-.*"] 
-  virt_macs:
-    - "52:54:00"
-    - "fa:16:3e"
-    - "06:f1:3a"
-    - "00:0d:3a" # Microsoft
-    - "00:50:56" # VMware
+  match_interfaces: .*
+  # Interface names that should be considered when detecting machine type.
+  # Takes a single regexps string as input. Only interface names matching
+  # the provided expression will be considered. The default value .* (or
+  # empty value) tells the detection algorithm to look through all interfaces.
+  # Example: match_interfaces: ^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+
+  virt_macs: []
+  # The list of MAC address prefixes to be considered as virtual machines.
+  # Example: virt_macs: ["52:54:00", "fa:16:3e", "06:f1:3a", "00:0d:3a", "00:50:56"]
 
 debug: False

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -16,7 +16,7 @@ detection: # parameters affecting the detection algorithm
   match_interfaces: ''
   # Interface names that should be considered when detecting machine type.
   # Takes a single regexp string as input. Only interface names matching
-  # the provided expression will be considered. The default value '' (or
+  # the provided expression will be considered. The default value '' is
   # empty value) tells the detection algorithm to look through all interfaces.
   # Example: match_interfaces: ^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+
   virt_macs: []

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -13,10 +13,10 @@ exporter:
   collect_interval: 15
 
 detection: # parameters affecting the detection algorithm
-  match_interfaces: .*
+  match_interfaces: ''
   # Interface names that should be considered when detecting machine type.
-  # Takes a single regexps string as input. Only interface names matching
-  # the provided expression will be considered. The default value .* (or
+  # Takes a single regexp string as input. Only interface names matching
+  # the provided expression will be considered. The default value '' (or
   # empty value) tells the detection algorithm to look through all interfaces.
   # Example: match_interfaces: ^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+
   virt_macs: []

--- a/tests/unit/config.yaml
+++ b/tests/unit/config.yaml
@@ -13,7 +13,7 @@ exporter:
   collect_interval: 15
 
 detection:
-  skip_interfaces: []
+  match_interfaces: ^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+
   virt_macs:
     - "52:54:00"
     - "fa:16:3e"

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -169,7 +169,7 @@ class TestCollectorDaemon:
     def test_get_machine_type_interface_match(
         self, match_interfaces, expected_type, collector_daemon
     ):
-        """Test that only whitelist interfaces are used to detect machine type.
+        """Test that only whitelisted interfaces are used to detect machine type.
 
         There are three scenarios to this test:
           * Without setting 'match_interfaces', the machine should be marked as KVM

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -159,19 +159,21 @@ class TestCollectorDaemon:
         assert machine_type.value == expect_machine_type
 
     @pytest.mark.parametrize(
-        "skip_interfaces, expected_type",
+        "match_interfaces, expected_type",
         [
-            ([r"^virbr\d*", r"^tap-"], MachineType.METAL),
-            ([], MachineType.KVM),
+            (r"^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+", MachineType.METAL),
+            (r".*", MachineType.KVM),
+            (r"", MachineType.KVM),
         ],
     )
-    def test_get_machine_type_interface_skip(
-        self, skip_interfaces, expected_type, collector_daemon
+    def test_get_machine_type_interface_match(
+        self, match_interfaces, expected_type, collector_daemon
     ):
-        """Test that blacklisted interfaces are not used to detect machine type.
+        """Test that only whitelist interfaces are used to detect machine type.
 
-        There are two scenarios to this test:
-          * Without setting 'skip_interfaces', the machine should be marked as KVM
+        There are three scenarios to this test:
+          * Without setting 'match_interfaces', the machine should be marked as KVM
+          * Setting 'match_interfaces' to match all, the machine should be marked as KVM
           * With right interfaces skipped, the machine should be marked as METAL
         """
         statsd = collector_daemon()
@@ -197,7 +199,7 @@ class TestCollectorDaemon:
         }
 
         statsd.config["detection"]["virt_macs"].set([kvm_prefix, tap_prefix])
-        statsd.config["detection"]["skip_interfaces"].set(skip_interfaces)
+        statsd.config["detection"]["match_interfaces"].set(match_interfaces)
 
         assert statsd._get_machine_type(machine, "dummy-0") == expected_type
 


### PR DESCRIPTION
Allow user to define a whitelist of interfaces to be used by the detection algorithm. This approach supersedes the previous blacklist approach as this is more robust.

Fixes: https://github.com/canonical/prometheus-juju-exporter/issues/31