### PR TITLE
Backward compatible feature to specify more than one controller endpoint

### DIFF
--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -5,7 +5,6 @@ from logging import getLogger
 from typing import Any, Dict, List
 
 from juju.controller import Controller
-from juju.errors import JujuError
 
 from prometheus_juju_exporter.config import Config
 
@@ -67,7 +66,8 @@ class Collector:
                         endpoint=endpoint, username=username, password=password, cacert=cacert
                     )
                     break
-                except JujuError as exc:
+                except Exception as exc:  # pylint: disable=W0718
+                    # Controller.connect() can raise generic `Exception`
                     self.logger.warning(
                         "Failed to connect to Juju controller at %s: %s", endpoint, exc
                     )

--- a/prometheus_juju_exporter/collector.py
+++ b/prometheus_juju_exporter/collector.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from typing import Any, Dict, List
 
 from juju.controller import Controller
+from juju.errors import JujuError
 
 from prometheus_juju_exporter.config import Config
 
@@ -47,11 +48,11 @@ class Collector:
         self.controller = Controller(max_frame_size=6**24)
 
     async def _connect_controller(
-        self, endpoint: str, username: str, password: str, cacert: str
+        self, endpoints: List[str], username: str, password: str, cacert: str
     ) -> None:
         """Connect to a controller via its endpoint.
 
-        :param str endpoint: the hostname:port endpoint of the controller
+        :param List[str] endpoints: list of the hostname:port endpoints of the controllers
             to connect to.
         :param str username: the username for controller-local users
         :param str password: the password for controller-local users
@@ -59,9 +60,20 @@ class Collector:
             (PEM formatted)
         """
         if not self.controller.is_connected():
-            await self.controller.connect(
-                endpoint=endpoint, username=username, password=password, cacert=cacert
-            )
+            for endpoint in endpoints:
+                self.logger.info("Connecting to controller at %s", endpoint)
+                try:
+                    await self.controller.connect(
+                        endpoint=endpoint, username=username, password=password, cacert=cacert
+                    )
+                    break
+                except JujuError as exc:
+                    self.logger.warning(
+                        "Failed to connect to Juju controller at %s: %s", endpoint, exc
+                    )
+                    continue
+            else:
+                raise RuntimeError("Unable to connect to any of the Juju controllers.")
 
     async def _get_machines_in_model(self, uuid: str) -> Dict[Any, Any]:
         """Get a list of all machines in the model with their stats.
@@ -242,14 +254,14 @@ class Collector:
         ]
         self.refresh_cache(gauge_name=gauge_name, gauge_desc=gauge_desc, labels=labels)
 
-        endpoint = self.config["juju"]["controller_endpoint"].get(str)
+        endpoints: List[str] = self.config["juju"]["controller_endpoint"].as_str_seq(split=False)
         username = self.config["juju"]["username"].get(str)
         password = self.config["juju"]["password"].get(str)
         cacert = self.config["juju"]["controller_cacert"].get(str)
 
         try:
             await self._connect_controller(
-                endpoint=endpoint, username=username, password=password, cacert=cacert
+                endpoints=endpoints, username=username, password=password, cacert=cacert
             )
             model_uuids = await self.controller.model_uuids()
             self.logger.debug("List of models in controller: %s", model_uuids)

--- a/prometheus_juju_exporter/config.py
+++ b/prometheus_juju_exporter/config.py
@@ -47,7 +47,7 @@ class Config(metaclass=ConfigMeta):
             ),
             "juju": OrderedDict(
                 [
-                    ("controller_endpoint", str),
+                    ("controller_endpoint", confuse.StrSeq(split=False)),
                     ("controller_cacert", str),
                     ("username", str),
                     ("password", str),

--- a/prometheus_juju_exporter/config_default.yaml
+++ b/prometheus_juju_exporter/config_default.yaml
@@ -3,7 +3,9 @@ customer:
   cloud_name: "example_cloud"
 
 juju:
-  controller_endpoint: "" # e.g. 192.168.1.100:17070
+  controller_endpoint: ""
+  # This option accepts either single string like "192.168.1.100:17070", or in
+  # case of a HA controller setup, a list of strings ["10.0.0.1:17070", "10.0.0.2:17070"]
   controller_cacert: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
   username: "example_user"
   password: "example_password"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -39,6 +39,17 @@ class TestConfig:
             config_ins.validate_config_options()
             exit_call.assert_not_called()
 
+    @pytest.mark.parametrize("endpoint", ["10.0.0.1:17070", "10.0.0.1:17070,10.0.0.2:17070"])
+    def test_validate_config_option_controller_endpoint(self, endpoint, config_instance):
+        """Test that both 'single string' and 'list of strings' pass validation.
+
+        config option 'juju.controller_endpoint' can accept either single string or list
+        of strings. This test makes sure that both formats pass the final verification.
+        """
+        test_config = config_instance()
+        test_config.config["juju"]["controller_endpoint"].set(endpoint)
+        test_config.validate_config_options()
+
     @pytest.mark.parametrize("port_value", ("foo", 65536, None))
     def test_validate_config_options_fail(self, config_instance, port_value):
         """Test validate_config_values function."""


### PR DESCRIPTION
This change allow specification of multiple controllers in the config file. This is meant to accommodate HA juju setups with multiple controllers, not to specify multiple standalone controllers.  Collector will automatically fail over to the next controller in the list in case the first controller on the list fails.