### PR TITLE
Specify architectures in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,8 @@ description: |
   Collects juju machine status metrics periodically.
   Provides a prometheus exporter interface exposing the collected metrics.
 architectures:
-  - build-on: amd64
-  - build-on: arm64
+  - amd64
+  - arm64
 
 grade: stable
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,6 +6,9 @@ summary: collects and exports juju machine status metrics
 description: |
   Collects juju machine status metrics periodically.
   Provides a prometheus exporter interface exposing the collected metrics.
+architectures:
+  - build-on: amd64
+  - build-on: arm64
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
Specify architectures as `amd64` and `arm64` on snapcraft.yaml. If we don't specify this, snapcraft tries to build for all available architectures and [fails for most of them](https://snapcraft.io/prometheus-juju-exporter/builds).