### PR TITLE
Fix the broken sonar workflow and apply reusable sonar workflow

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,109 +1,14 @@
 name: SonarCloud
 on:
   workflow_run:
-    workflows: [PR workflow running lint checkers, unit and functional tests]
+    workflows:
+      - PR workflow running lint checkers, unit and functional tests
     types: [completed]
 
 jobs:
   sonarcloud:
-    name: SonarCloud
-    runs-on: ubuntu-latest
+    uses: canonical/bootstack-actions/.github/workflows/sonar.yaml@main
+    secrets: inherit
     if: github.event.workflow_run.conclusion == 'success'
-    steps:
-      - name: Echo event info
-        run: cat $GITHUB_EVENT_PATH
-      - name: Download PR number artifact
-        if: github.event.workflow_run.event == 'pull_request'
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: CI Setup
-          run_id: ${{ github.event.workflow_run.id }}
-          name: PR_NUMBER
-      - name: Read PR_NUMBER.txt
-        if: github.event.workflow_run.event == 'pull_request'
-        id: pr_number
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./PR_NUMBER.txt
-      - name: Request GitHub API for PR data
-        if: github.event.workflow_run.event == 'pull_request'
-        uses: octokit/request-action@v2.x
-        id: get_pr_data
-        with:
-          route: GET /repos/{full_name}/pulls/{number}
-          number: ${{ steps.pr_number.outputs.content }}
-          full_name: ${{ github.event.repository.full_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Initialized repository
-        uses: actions/checkout@v3
-        with:
-            repository: ${{ github.event.workflow_run.head_repository.full_name }}
-            ref: ${{ github.event.workflow_run.head_branch }}
-            fetch-depth: 0
-      - name: Checkout base branch
-        if: github.event.workflow_run.event == 'pull_request'
-        run: |
-            git remote add upstream ${{ github.event.repository.clone_url }}
-            git fetch upstream
-            git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-            git checkout ${{ github.event.workflow_run.head_branch }}
-            git clean -ffdx && git reset --hard HEAD
-
-      - name: Download coverage report
-        uses: actions/github-script@v5
-        with:
-            script: |
-              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: context.payload.workflow_run.id,
-              });
-              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-                return artifact.name == "coverage-report"
-              })[0];
-              let download = await github.rest.actions.downloadArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: matchArtifact.id,
-                archive_format: 'zip',
-              });
-              let fs = require('fs');
-              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
-
-      - name: Unzip code coverage
-        run: unzip artifact.zip
-
-      - name: Fix code coverage paths
-        working-directory: .
-        run: |
-            mkdir tests/unit/report
-            cp cov.xml tests/unit/report/coverage.xml
-
-      - name: SonarCloud Scan on PR
-        if: github.event.workflow_run.event == 'pull_request'
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          projectBaseDir: '.'
-          args: >
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}
-            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-            -Dproject.settings=sonar-project.properties
-
-      - name: SonarCloud Scan on push
-        if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == ${{ github.event.workflow_run.head_repository.full_name }}
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          projectBaseDir: '.'
-          args: >
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
-            -Dproject.settings=sonar-project.properties
+    with:
+      workflow-name: PR workflow running lint checkers, unit and functional tests


### PR DESCRIPTION
The sonar workflow was broken because the triggering workflow name contains a comma, which the square-bracket list notation ("[ ]") treated as a separator between two names (`PR workflow running lint checkers` and `unit and functional tests` instead of `PR workflow running lint checkers, unit and functional tests`). This PR fixes this issue.

Additionally, with the base sonar integration being added to [bootstack-actions](https://github.com/canonical/bootstack-actions), we should apply the reusable workflow.

Notes:
- This PR relies on the changes introduced in https://github.com/canonical/bootstack-actions/pull/22. Therefore, we should not merge the former before the latter. 
- The changes in sonar.yaml file will not take effect until they land in the default branch