### PR TITLE
Update libjuju version to include its fix for exception handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ asyncio
 
 # Pinning the last release that was
 # natively designed for Juju 2.9
-juju == 2.9.11
+juju<3


### PR DESCRIPTION
The [changes](https://github.com/juju/python-libjuju/pull/833) in libjuju that fix https://github.com/canonical/prometheus-juju-exporter/issues/42 has been merged and released (v2.9.42.2). With the fix, the program no longer hangs; it will skip the unreachable model and print out an error log:

```
2023-05-11T22:37:44Z prometheus-juju-exporter.prometheus-juju-exporter[3239]: 2023-05-11 22:37:44,877 DEBUG - Checking model 'broken2'...
2023-05-11T22:37:44Z prometheus-juju-exporter.prometheus-juju-exporter[3239]: 2023-05-11 22:37:44,956 ERROR - Failed connecting to model '<model id>': model migration in progress
2023-05-11T22:37:44Z prometheus-juju-exporter.prometheus-juju-exporter[3239]: 2023-05-11 22:37:44,957 DEBUG - Checking model 'controller'...
...
```

This PR updates libjuju dependency in `requirements.txt` to track the latest release for 2.9 series.

closes: #42 