### PR TITLE
Revert "Update libjuju version to include its fix for exception handling"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ asyncio
 
 # Pinning the last release that was
 # natively designed for Juju 2.9
-juju<3
+juju == 2.9.11


### PR DESCRIPTION
Reverts canonical/prometheus-juju-exporter#50 because libjuju 2.9.42.2 is not compatible with juju 2.7 and 2.8 controllers.

relates to: #51 