### PR TITLE
Add snap release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Publish snap
+
+on:
+  push:
+    branches:
+      - '[0-9].[0-9]+'
+      - main
+      - master
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    uses: canonical/bootstack-actions/.github/workflows/snap-release.yaml@main
+    secrets: inherit
+    with:
+      python-version-unit: "['3.8', '3.10']"
+      python-version-func: "3.10"
+      tox-version: "<4"
+      snapcraft: true
+      commands: "['make functional']"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
       tox-version: "<4"
       snapcraft: true
       commands: "['make functional']"
-      # Select latest track for the default branch, otherwise use versioned branch name as the track name
-      track: ${{ contains(fromJSON('["main", "master"]'), github.ref_name) && 'latest' || github.ref_name }}
-      risk-level: edge
+      # "channel" should be one or a (comma-separated) list of <track>/<risk-level>
+      # Check if the current branch is the default ("main" or "master"). If true, track is set to "latest";
+      # otherwise, use the versioned branch name as the track name
+      # The risk level we want to release the snap to is "edge"
+      channel: ${{ contains(fromJSON('["main", "master"]'), github.ref_name) && 'latest' || github.ref_name }}/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - '[0-9].[0-9]+'
       - main
       - master
-  workflow_call:
   workflow_dispatch:
 
 jobs:
@@ -19,3 +18,6 @@ jobs:
       tox-version: "<4"
       snapcraft: true
       commands: "['make functional']"
+      # Select latest track for the default branch, otherwise use versioned branch name as the track name
+      track: ${{ contains(fromJSON('["main", "master"]'), github.ref_name) && 'latest' || github.ref_name }}
+      risk-level: edge

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install snap from a specific channel, e.g. `2.9/stable`, use `--channel` flag
 ```bash
 sudo snap install prometheus-juju-exporter --channel 2.9/stable
 ```
-**Note**: please refer to [Juju Version Compatibility](#juju-version-compatibility) to select the proper snap channel base on the version of juju controller that the snap will communicate with.
+**Note**: please refer to [Juju Version Compatibility](#juju-version-compatibility) to select the proper snap channel depending on the version of the juju controller that the snap will communicate with.
 
 To get the latest development version of the snap, build from the source code and install with `--dangerous` flag:
 ```bash
@@ -29,7 +29,7 @@ The snap requires juju user's credentials to connect to a controller and all of 
 
 
 ## Juju Version Compatibility
-Due to the limitations of Juju's cross-version support, channels and versions are used in the snap to accommodate different juju controller versions. The following table demonstrates the compatibility matrix between juju controller version, snap channel, snap version, and branch in the repository. The operator should select the proper snap channel at installation time accordingly.
+Due to the limitations of libjuju's cross-version support, channels and versions are used in the snap to accommodate different juju controller versions. The following table demonstrates the compatibility matrix between juju controller version, snap channel, snap version, and branch in the repository. The operator should select the proper snap channel at installation time accordingly.
 
 | Juju Controller Version | Snap Channel                              | Repo Branch | Snap Version |
 |-------------------------|-------------------------------------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ To get the latest stable version of the snap from Snapstore, run:
 ```bash
 sudo snap install prometheus-juju-exporter
 ```
+
+To install snap from a specific channel, e.g. `2.9/stable`, use `--channel` flag:
+```bash
+sudo snap install prometheus-juju-exporter --channel 2.9/stable
+```
+**Note**: please refer to [Juju Version Compatibility](#juju-version-compatibility) to select the proper snap channel base on the version of juju controller that the snap will communicate with.
+
 To get the latest development version of the snap, build from the source code and install with `--dangerous` flag:
 ```bash
 make build
@@ -19,3 +26,12 @@ By default, prometheus-juju-exporter uses the configuration specified in [config
 The snap requires juju user's credentials to connect to a controller and all of its models. The credentials are set as `juju.username` and `juju.password` config values. Normally, **`superuser`** privilege is expected for such a user for full access to the controller. However, in case it is not possible, the minimum privilege requirements are:
 1. `login` access to the controller instance and `admin` access to the model hosting the controller
 2. `admin` access to any model that's expected to be monitored by this exporter
+
+
+## Juju Version Compatibility
+Due to the limitations of Juju's cross-version support, channels and versions are used in the snap to accommodate different juju controller versions. The following table demonstrates the compatibility matrix between juju controller version, snap channel, snap version, and branch in the repository. The operator should select the proper snap channel at installation time accordingly.
+
+| Juju Controller Version | Snap Channel                              | Repo Branch | Snap Version |
+|-------------------------|-------------------------------------------|-------------|--------------|
+| 2.8 and older           | 2.8/stable<br/>2.8/candidate<br/>2.8/edge | 2.8         | 1.x          |
+| 2.9                     | 2.9/stable<br/>2.9/candidate<br/>2.9/edge | 2.9         | 2.x          |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,7 @@ description: |
   Collects juju machine status metrics periodically.
   Provides a prometheus exporter interface exposing the collected metrics.
 architectures:
-  - amd64
-  - arm64
+  - build-on: amd64
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
This PR adds snap release workflow. It calls the `snap-release.yaml` reusable workflow in [bootstack-actions](https://github.com/canonical/bootstack-actions) to build the snap and release it to a proper channel in Snap Store. The workflow will be triggered when changes are pushed to either the default branch (`master` or `main`) or a versioned branch (e.g. `2.9`).

Additionally, this PR updates the README file to include channel selection information and strategy.

The workflow should not be merged until https://github.com/canonical/bootstack-actions/pull/25 lands in its main branch. Upon approval, this workflow should be added to the [bootstack-charms-spec](https://launchpad.net/bootstack-charms-spec) repo.

relates to: https://github.com/canonical/prometheus-juju-exporter/issues/51