### PR TITLE
Update libjuju version to include its fix for exception handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ asyncio
 
 # Pinning the last release that was
 # natively designed for Juju 2.9
-juju == 2.9.11
+juju<3


### PR DESCRIPTION
This PR redo the changes reverted in #52: bumping libjuju version to include fixes addressing exception handling issue reported in #42 .

closes: https://github.com/canonical/prometheus-juju-exporter/issues/42