### PR TITLE
feat: add juju 3.1 support

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ name: PR workflow running lint checkers, unit and functional tests
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ master, main ]
+    branches: [ 3.1 ]
     paths-ignore:
       - '**.md'
       - '**.rst'
@@ -22,3 +22,4 @@ jobs:
       tox-version: "<4"
       snapcraft: true
       commands: "['make functional']"
+      juju-channel: "3.1/stable"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ name: PR workflow running lint checkers, unit and functional tests
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ 3.1 ]
+    branches: [ master, main ]
     paths-ignore:
       - '**.md'
       - '**.rst'

--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ Due to the limitations of libjuju's cross-version support, channels and versions
 |-------------------------|-------------------------------------------|-------------|--------------|
 | 2.8 and older           | 2.8/stable<br/>2.8/candidate<br/>2.8/edge | 2.8         | 1.x          |
 | 2.9                     | 2.9/stable<br/>2.9/candidate<br/>2.9/edge | 2.9         | 2.x          |
+| 3.1                     | 3.1/stable<br/>3.1/candidate<br/>3.1/edge | 3.1         | 3.x          |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 prometheus-client
 confuse
 asyncio
-
-# Pinning the last release that was
-# natively designed for Juju 2.9
 juju

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ asyncio
 
 # Pinning the last release that was
 # natively designed for Juju 2.9
-juju<3
+juju


### PR DESCRIPTION
New branch: `3.1` created for 3.1 series. he new track is [requested](https://forum.snapcraft.io/t/track-request-for-prometheus-juju-exporter-snap/36734) however not granted yet, so the publish workflow will fail, however we can trigger it manually whenever we are granted the track.