### PR TITLE
fix: run release with juju 3.1 also

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       tox-version: "<4"
       snapcraft: true
       commands: "['make functional']"
+      juju-channel: "3.1/stable"
       # "channel" should be one or a (comma-separated) list of <track>/<risk-level>
       # Check if the current branch is the default ("main" or "master"). If true, track is set to "latest";
       # otherwise, use the versioned branch name as the track name


### PR DESCRIPTION
This was missed in #57 , the release pipeline failed as a result of that.