### PR TITLE
test: juju destroy-model command no prompt option backward compatible

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -128,4 +128,7 @@ def setup_test_model():
     yield test_model_name
 
     logging.info("Destroying model '%s'...", test_model_name)
-    check_call(f"juju destroy-model --destroy-storage --force -y {test_model_name}".split())
+
+    check_call(
+        f"juju destroy-model --destroy-storage  --force --no-prompt {test_model_name}".split()
+    )

--- a/tests/functional/helpers.py
+++ b/tests/functional/helpers.py
@@ -106,5 +106,5 @@ def add_machine():
 
 def remove_machine():
     """Remove a machine from the test model."""
-    assert check_call("juju remove-machine 0".split()) == 0  # noqa
+    assert check_call("juju remove-machine 0 --no-prompt".split()) == 0  # noqa
     juju_wait_until_complete()


### PR DESCRIPTION
juju has a breaking change on 3.2 that change `-y` to `--no-prompt`.
This PR make the functional test backward compatible.