### PR TITLE
Change juju3 release strategy

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ master, main , '[0-9].[0-9]+']
+    branches: [ master, main , '[0-9].[0-9]+', '[0-9]+']
     paths-ignore:
       - '**.md'
       - '**.rst'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '[0-9].[0-9]+'
+      - '[0-9]+'
       - main
       - master
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,4 @@ Due to the limitations of libjuju's cross-version support, channels and versions
 |-------------------------|-------------------------------------------|-------------|--------------|
 | 2.8 and older           | 2.8/stable<br/>2.8/candidate<br/>2.8/edge | 2.8         | 1.x          |
 | 2.9                     | 2.9/stable<br/>2.9/candidate<br/>2.9/edge | 2.9         | 2.x          |
-| 3.1                     | 3.1/stable<br/>3.1/candidate<br/>3.1/edge | 3.1         | 3.1          |
-| 3.2                     | 3.2/stable<br/>3.2/candidate<br/>3.2/edge | 3.2         | 3.2          |
-| 3.3                     | 3.3/stable<br/>3.3/candidate<br/>3.3/edge | 3.3         | 3.3          |
-| 3.4                     | 3.4/stable<br/>3.4/candidate<br/>3.4/edge | 3.4         | 3.4          |
+| 3.x                     | 3.1/stable<br/>3.1/candidate<br/>3.1/edge | 3           | 3            |

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Due to the limitations of libjuju's cross-version support, channels and versions
 |-------------------------|-------------------------------------------|-------------|--------------|
 | 2.8 and older           | 2.8/stable<br/>2.8/candidate<br/>2.8/edge | 2.8         | 1.x          |
 | 2.9                     | 2.9/stable<br/>2.9/candidate<br/>2.9/edge | 2.9         | 2.x          |
-| 3.x                     | 3/stable<br/>3/candidate<br/>3/edge       | 3           | 3            |
+| 3.x                     | 3/stable<br/>3/candidate<br/>3/edge       | 3           | 3.x          |

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Due to the limitations of libjuju's cross-version support, channels and versions
 |-------------------------|-------------------------------------------|-------------|--------------|
 | 2.8 and older           | 2.8/stable<br/>2.8/candidate<br/>2.8/edge | 2.8         | 1.x          |
 | 2.9                     | 2.9/stable<br/>2.9/candidate<br/>2.9/edge | 2.9         | 2.x          |
-| 3.x                     | 3.1/stable<br/>3.1/candidate<br/>3.1/edge | 3           | 3            |
+| 3.x                     | 3/stable<br/>3/candidate<br/>3/edge       | 3           | 3            |


### PR DESCRIPTION
All the 3.x juju should use branch 3 as default. Since python-libjuju is backward compatibility, see [link](https://github.com/juju/python-libjuju/issues/1039#issuecomment-2037528699).

- Branch `3` and tag/release will be created later base on this commit after merged
- All the 3.x branches will be there but no longer be maintained.
- For upgrading, user should able to upgrade their snap by `sudo snap refresh prometheus-juju-exporter --channel=3/stable`