### PR TITLE
Support Juju 3.4

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,6 @@ jobs:
     with:
       python-version-unit: "['3.8', '3.10']"
       python-version-func: "3.10"
-      tox-version: "<4"
+      juju-channel: "3.4/stable"
       snapcraft: true
       commands: "['make functional']"
-      juju-channel: "3.1/stable"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,10 @@ on:
       - '**.md'
       - '**.rst'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr:
     uses: canonical/bootstack-actions/.github/workflows/pull-request.yaml@main


### PR DESCRIPTION
Changing to use of Juju 3.4 controller for testing instead of Juju 3.1.

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.