### PR TITLE
Add workflow_call to pr.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,7 @@ name: PR workflow running lint checkers, unit and functional tests
 
 on:
   workflow_dispatch:
+  workflow_call:
   pull_request:
     types: [ opened, synchronize, reopened ]
     branches: [ master, main , '[0-9].[0-9]+', '[0-9]+']

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install yq
-        run: sudo apt update && sudo apt install yq -y
+        run: sudo snap install yq
       - name: Snapcraft install
         run: sudo snap install --classic snapcraft
       - name: Snapcraft login

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -27,7 +27,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         run: |
-          snapcraft ${{ steps.snap.outputs.name }}  \
+          snapcraft promote ${{ steps.snap.outputs.name }}  \
           --from-channel ${{ github.event.inputs.origin-channel }} \
           --to-channel ${{ github.event.inputs.destination-channel }} \
           --yes

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -29,5 +29,4 @@ jobs:
         run: |
           snapcraft promote ${{ steps.snap.outputs.name }}  \
           --from-channel ${{ github.event.inputs.origin-channel }} \
-          --to-channel ${{ github.event.inputs.destination-channel }} \
-          --yes
+          --to-channel ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,18 +20,14 @@ jobs:
         run: sudo snap install yq
       - name: Snapcraft install
         run: sudo snap install --classic snapcraft
-      - name: Snapcraft login
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        run: snapcraft login
       - name: Get snap name
         id: snap
         run: echo "name=$(yq '.name' snap/snapcraft.yaml)" >> $GITHUB_OUTPUT
       - name: Snapcraft promote snap
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         run: |
           snapcraft ${{ steps.snap.outputs.name }}  \
           --from-channel ${{ github.event.inputs.origin-channel }} \
           --to-channel ${{ github.event.inputs.destination-channel }} \
           --yes
-      - name: Snapcraft logout
-        run: snapcraft logout

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,4 +1,4 @@
-name: Promote charm to other tracks and channels
+name: Promote snap to other tracks and channels
 
 on:
   workflow_dispatch:
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install yq
-        run: apt update && apt install yq -y
+        run: sudo apt update && sudo apt install yq -y
       - name: Snapcraft install
-        run: snap install --classic snapcraft
+        run: sudo snap install --classic snapcraft
       - name: Snapcraft login
         run: snapcraft login --with ${{ secrets.STORE_LOGIN }}
       - name: Get snap name

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -21,7 +21,10 @@ jobs:
       - name: Snapcraft install
         run: sudo snap install --classic snapcraft
       - name: Snapcraft login
-        run: snapcraft login --with ${{ secrets.STORE_LOGIN }}
+        run: |
+          ${{ secrets.STORE_LOGIN }} > login.txt
+          snapcraft login --with login.txt
+          rm login.txt
       - name: Get snap name
         id: snap
         run: echo "name=$(yq '.name' snap/snapcraft.yaml)" >> $GITHUB_OUTPUT

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -26,7 +26,11 @@ jobs:
       - name: Snapcraft promote snap
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+          SNAPCRAFT_HAS_TTY: "true" # this is necessary because snapcraft will not allow --yes for promotions of the edge channel https://github.com/canonical/snapcraft/issues/4439
         run: |
-          snapcraft promote ${{ steps.snap.outputs.name }}  \
+          # Note: using `yes |` instead of `--yes` because snapcraft will
+          #       refuse to non-interactively promote a snap from the edge
+          #       channel if it is done without any branch qualifiers
+          yes | snapcraft promote ${{ steps.snap.outputs.name }}  \
           --from-channel ${{ github.event.inputs.origin-channel }} \
           --to-channel ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -21,10 +21,9 @@ jobs:
       - name: Snapcraft install
         run: sudo snap install --classic snapcraft
       - name: Snapcraft login
-        run: |
-          ${{ secrets.STORE_LOGIN }} > login.txt
-          snapcraft login --with login.txt
-          rm login.txt
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        run: snapcraft login
       - name: Get snap name
         id: snap
         run: echo "name=$(yq '.name' snap/snapcraft.yaml)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/pr.yaml
     secrets: inherit
 
-  build:
+  release:
     runs-on: ubuntu-latest
     needs: check
     outputs:
@@ -24,17 +24,9 @@ jobs:
         with:
           name: snap
           path: ${{ steps.build.outputs.snap }}
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: snap
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: ${{ needs.build.outputs.snap }}
+          snap: ${{ steps.build.outputs.snap }}
           release: latest/edge,3/edge


### PR DESCRIPTION
Now I understand why we need to have workflow_call, since without it, it's not possible to call this from another workflow, e.g. release.yaml.