### PR TITLE
chore: apply new github bot for jira and gh sync and remove the old jira_gh sync action

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -17,6 +17,9 @@ settings:
   components:
     - juju-exporter
 
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: SOLENG-46
+
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug
   label_mapping:

--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,23 @@
+#
+# For more info about the settings, please refre to the github repository:
+# https://github.com/canonical/gh-jira-sync-bot
+#
+
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "SOLENG"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  components:
+    - juju-exporter
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story


### PR DESCRIPTION
Apply new GitHub bot for jira and gh sync, and optionally (if there's any) remove the old jira to gh sync action.