### PR TITLE
Ensure git history is available for snap version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
       snap: ${{ steps.build.outputs.snap }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for version determination
       - uses: snapcore/action-build@v1
         id: build
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The snap git version script
(via snapcraft.yaml -> setup.py version -> setuptools scm version)
needs git history available so it can correctly set the git version.

actions/checkout@v4 only fetches a single revision by default,
which means the git version script will not return expected results.

So we must set fetch-depth to 0 to get the full git version history,
so it's available for the git version script.
